### PR TITLE
✨ Improve profile pic sizing

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -6,7 +6,7 @@ export const RemotionRoot: React.FC = () => {
 	return (
     <>
     <Folder name="HT-Nantes-Avril">
-      {talks.map((talk, index) => (
+      {talks.map(talk => (
         <Composition
           id={talk.pos}
           durationInFrames={120}

--- a/src/components/Speakers.tsx
+++ b/src/components/Speakers.tsx
@@ -16,7 +16,7 @@ export const Speakers = ({ speakers }: SpeakersProps) => {
       position: "absolute",
       display: "flex",
       gap: "160px",
-      height: "30%",
+      width: "100%",
       justifyContent: "center",
       top: `${top}px`
     }}>
@@ -42,7 +42,7 @@ const Speaker = ({ name, pic }: SpeakerProps) => {
       display: "flex",
       flexDirection: "column",
       gap: "28px",
-      width: "100%"
+      width: "20%"
     }}>
       <Img style={{
         border: "4px solid white",


### PR DESCRIPTION
Salut @jeanphibaconnais :wave: J'ai rendu les tailles des profile pic constantes. Le souci était que le nom du speaker fixait la taille du bloc : un long nom = grande image et inversement. Voilà ce que ça donne mtn:

| Angi | Hadrien |
| --- | --- |
| ![image](https://github.com/Human-Talks/human-talks-promote-event/assets/50751082/2e93762c-50f4-467e-852c-f182607ad1c5) | ![image](https://github.com/Human-Talks/human-talks-promote-event/assets/50751082/848f8818-6971-466c-ad02-a4fc571b9b4a) |